### PR TITLE
Add css to fix blue border around active package

### DIFF
--- a/stylesheets/themed-settings.less
+++ b/stylesheets/themed-settings.less
@@ -139,6 +139,12 @@ body .settings-view {
 		border-color: @base-border-color;
 	}
 
+	.config-menu .panels-packages li.active {
+		a, a:hover {
+			box-shadow: 0 0 0 1px darken(@background-color-selected, 6%) !important;
+		}
+	}
+
 	.error-message .error-details {
 		background: @inset-panel-background-color;
 		border: @inset-panel-border-color;


### PR DESCRIPTION
A box shadow was added to the package menu - active package [1].  I added a fix so it gets themed.

[1] https://github.com/atom/settings-view/blame/master/stylesheets/settings-view.less#L199
