### PR TITLE
Shadow Dom support

### DIFF
--- a/stylesheets/themed-settings.less
+++ b/stylesheets/themed-settings.less
@@ -43,15 +43,16 @@ body .settings-view {
 			.cursor {
 				border-color: @text-color-highlight;
 			}
-			&.is-focused {
-				background: lighten(@input-background-color, 5%);
-				border: 1px solid @input-border-color;
-				.cursor {
-					border-color: @text-color-highlight;
-				}
-				&.editor-colors .selection .region {
-					background-color: desaturate(@background-color-info, 50%);
-				}
+		}
+
+		&.is-focused, &.is-focused::shadow {
+			background: lighten(@input-background-color, 5%);
+			border: 1px solid @input-border-color;
+			.cursor {
+				border-color: @text-color-highlight;
+			}
+			&.editor-colors .selection .region {
+				background-color: desaturate(@background-color-info, 50%);
 			}
 		}
 


### PR DESCRIPTION
If you enable `Use Shadow DOM` in the settings, the inputs loose some styling. This PR adds the `::shadow` selector. Plus had to add the `.mini.mini` to win the specifity fight.
