### PR TITLE
Update mini editor selector

### DIFF
--- a/stylesheets/themed-settings.less
+++ b/stylesheets/themed-settings.less
@@ -28,7 +28,7 @@ body .settings-view {
 
 	}
 
-	.editor-container atom-text-editor.mini.mini, select.form-control {
+	.editor-container atom-text-editor[mini][mini], select.form-control {
 		background: @input-background-color;
 		border: 1px solid @input-border-color;
 		color: @text-color;


### PR DESCRIPTION
Sorry, the proper selector for the mini editors is `atom-text-editor[mini]`. Ref: https://atom.io/docs/v0.152.0/upgrading/upgrading-your-ui-theme#custom-tags

It's not that urgent, but just in case the `.mini` class gets removed one day.
